### PR TITLE
Update api version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.12.6 AS build
-WORKDIR /go/src/github.com/Laica-Lunasys/oauth2-proxy-manager
+WORKDIR /go/src/github.com/wantedly/oauth2-proxy-manager
 
 ENV GOOS linux
 ENV CGO_ENABLED 0
@@ -15,6 +15,6 @@ FROM alpine
 WORKDIR /app
 
 EXPOSE 8080
-COPY --from=build /go/src/github.com/Laica-Lunasys/oauth2-proxy-manager/oauth2-proxy-manager /app/
+COPY --from=build /go/src/github.com/wantedly/oauth2-proxy-manager/oauth2-proxy-manager /app/
 
 ENTRYPOINT ["/app/oauth2-proxy-manager"]

--- a/cmd/oauth2-proxy-manager/main.go
+++ b/cmd/oauth2-proxy-manager/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"os"
 
-	"github.com/Laica-Lunasys/oauth2-proxy-manager/logger"
-	"github.com/Laica-Lunasys/oauth2-proxy-manager/service"
 	"github.com/sirupsen/logrus"
+	"github.com/wantedly/oauth2-proxy-manager/logger"
+	"github.com/wantedly/oauth2-proxy-manager/service"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"

--- a/create-oauth2-proxy.Dockerfile
+++ b/create-oauth2-proxy.Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.12.6 AS build
-WORKDIR /go/src/github.com/Laica-Lunasys/oauth2-proxy-manager
+WORKDIR /go/src/github.com/wantedly/oauth2-proxy-manager
 
 ENV GOOS linux
 ENV CGO_ENABLED 0
@@ -15,6 +15,6 @@ FROM alpine
 WORKDIR /app
 
 EXPOSE 8080
-COPY --from=build /go/src/github.com/Laica-Lunasys/oauth2-proxy-manager/create-oauth2-proxy /app/
+COPY --from=build /go/src/github.com/wantedly/oauth2-proxy-manager/create-oauth2-proxy /app/
 
 ENTRYPOINT ["/app/create-oauth2-proxy"]

--- a/ingress-observer.Dockerfile
+++ b/ingress-observer.Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.12.6 AS build
-WORKDIR /go/src/github.com/Laica-Lunasys/oauth2-proxy-manager
+WORKDIR /go/src/github.com/wantedly/oauth2-proxy-manager
 
 ENV GOOS linux
 ENV CGO_ENABLED 0
@@ -15,6 +15,6 @@ FROM alpine
 WORKDIR /app
 
 EXPOSE 8080
-COPY --from=build /go/src/github.com/Laica-Lunasys/oauth2-proxy-manager/ingress-observer /app/
+COPY --from=build /go/src/github.com/wantedly/oauth2-proxy-manager/ingress-observer /app/
 
 ENTRYPOINT ["/app/ingress-observer"]

--- a/service/controller.go
+++ b/service/controller.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	appsv1beta2 "k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -275,13 +275,13 @@ func (c *Controller) applyConfigMap(settings *models.ServiceSettings) {
 }
 
 func (c *Controller) applyDeployment(settings *models.ServiceSettings) {
-	deploymentsClient := c.Clientset.AppsV1beta2().Deployments("oauth2-proxy")
-	deployment := &appsv1beta2.Deployment{
+	deploymentsClient := c.Clientset.AppsV1().Deployments("oauth2-proxy")
+	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("oauth2-proxy-github-%s-%s", settings.GitHub.Organization, settings.AppName),
 			Namespace: "oauth2-proxy",
 		},
-		Spec: appsv1beta2.DeploymentSpec{
+		Spec: appsv1.DeploymentSpec{
 			Replicas: int32Ptr(1),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{

--- a/service/controller.go
+++ b/service/controller.go
@@ -13,8 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
-	"github.com/Laica-Lunasys/oauth2-proxy-manager/models"
 	"github.com/sirupsen/logrus"
+	"github.com/wantedly/oauth2-proxy-manager/models"
 	"k8s.io/client-go/kubernetes"
 )
 

--- a/service/observer.go
+++ b/service/observer.go
@@ -9,8 +9,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
-	"github.com/Laica-Lunasys/oauth2-proxy-manager/models"
 	"github.com/sirupsen/logrus"
+	"github.com/wantedly/oauth2-proxy-manager/models"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/fields"

--- a/showcase/create-oauth2-proxy/main.go
+++ b/showcase/create-oauth2-proxy/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	appsv1beta2 "k8s.io/api/apps/v1beta2"
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -299,13 +299,13 @@ func (o *OAuth2Proxy) applyConfigMap() {
 }
 
 func (o *OAuth2Proxy) applyDeployment() {
-	deploymentsClient := o.Clientset.AppsV1beta2().Deployments("oauth2-proxy")
-	deployment := &appsv1beta2.Deployment{
+	deploymentsClient := o.Clientset.AppsV1().Deployments("oauth2-proxy")
+	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("oauth2-proxy-github-%s-%s", o.Settings.GitHub.Organization, o.Settings.AppName),
 			Namespace: "oauth2-proxy",
 		},
-		Spec: appsv1beta2.DeploymentSpec{
+		Spec: appsv1.DeploymentSpec{
 			Replicas: int32Ptr(1),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{

--- a/showcase/create-oauth2-proxy/main.go
+++ b/showcase/create-oauth2-proxy/main.go
@@ -14,9 +14,9 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/Laica-Lunasys/oauth2-proxy-manager/logger"
-	"github.com/Laica-Lunasys/oauth2-proxy-manager/models"
 	"github.com/sirupsen/logrus"
+	"github.com/wantedly/oauth2-proxy-manager/logger"
+	"github.com/wantedly/oauth2-proxy-manager/models"
 	"k8s.io/client-go/kubernetes"
 )
 

--- a/showcase/ingress-observer/main.go
+++ b/showcase/ingress-observer/main.go
@@ -10,9 +10,9 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/rest"
 
-	"github.com/Laica-Lunasys/oauth2-proxy-manager/logger"
-	"github.com/Laica-Lunasys/oauth2-proxy-manager/models"
 	"github.com/sirupsen/logrus"
+	"github.com/wantedly/oauth2-proxy-manager/logger"
+	"github.com/wantedly/oauth2-proxy-manager/models"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/fields"


### PR DESCRIPTION
## Why

API version apps/v1beta2 in the Deployment Resource has been deprecated in Kubernetes v1.16.
ref. [Deprecated APIs Removed In 1\.16: Here’s What You Need To Know \| Kubernetes](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/)

## What

Updated the API version of the Deployment Resource created in this component to apps/v1.

Also, changed the import path from the original fork to this repository.