### PR TITLE
Replace extensions/v1beta1 with networking/v1

### DIFF
--- a/service/controller.go
+++ b/service/controller.go
@@ -153,8 +153,12 @@ func (c *Controller) applyIngress(ctx context.Context, settings *models.ServiceS
 								networkingv1.HTTPIngressPath{
 									Path: fmt.Sprintf("/github/%s", settings.AppName),
 									Backend: networkingv1.IngressBackend{
-										ServiceName: fmt.Sprintf("oauth2-proxy-%s-%s-%s", c.Env.Provider, settings.GitHub.Organization, settings.AppName),
-										ServicePort: intstr.FromInt(80),
+										Service: &networkingv1.IngressServiceBackend{
+											Name: fmt.Sprintf("oauth2-proxy-%s-%s-%s", c.Env.Provider, settings.GitHub.Organization, settings.AppName),
+											Port: networkingv1.ServiceBackendPort{
+												Number: 80,
+											},
+										},
 									},
 								},
 							},

--- a/service/observer.go
+++ b/service/observer.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/wantedly/oauth2-proxy-manager/models"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/cache"
 )
@@ -35,13 +35,13 @@ func (ob *Observer) Run(ctx context.Context) {
 	logrus.Info("[Observer] Observing Ingress...")
 
 	// create resource watcher (ingress)
-	watcher := cache.NewListWatchFromClient(ob.Clientset.ExtensionsV1beta1().RESTClient(), "ingresses", v1.NamespaceAll, fields.Everything())
+	watcher := cache.NewListWatchFromClient(ob.Clientset.NetworkingV1().RESTClient(), "ingresses", v1.NamespaceAll, fields.Everything())
 
-	_, controller := cache.NewInformer(watcher, &v1beta1.Ingress{}, 0, cache.ResourceEventHandlerFuncs{
+	_, controller := cache.NewInformer(watcher, &networkingv1.Ingress{}, 0, cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			key, err := cache.MetaNamespaceKeyFunc(obj)
 			if err == nil {
-				meta := obj.(*v1beta1.Ingress).ObjectMeta
+				meta := obj.(*networkingv1.Ingress).ObjectMeta
 				logrus.Infof("[Informer] Added Ingress %s", key)
 
 				settings, err := parseAnnotations(meta)
@@ -55,7 +55,7 @@ func (ob *Observer) Run(ctx context.Context) {
 			key, err := cache.MetaNamespaceKeyFunc(new)
 
 			if err == nil {
-				meta := new.(*v1beta1.Ingress).ObjectMeta
+				meta := new.(*networkingv1.Ingress).ObjectMeta
 				logrus.Infof("[Informer] Update Ingress %s", key)
 
 				settings, err := parseAnnotations(meta)
@@ -68,7 +68,7 @@ func (ob *Observer) Run(ctx context.Context) {
 		DeleteFunc: func(obj interface{}) {
 			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 			if err == nil {
-				meta := obj.(*v1beta1.Ingress).ObjectMeta
+				meta := obj.(*networkingv1.Ingress).ObjectMeta
 				logrus.Infof("[Informer] Delete Ingress: %s", key)
 
 				settings, err := parseAnnotations(meta)

--- a/showcase/ingress-observer/main.go
+++ b/showcase/ingress-observer/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/wantedly/oauth2-proxy-manager/logger"
 	"github.com/wantedly/oauth2-proxy-manager/models"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -57,13 +57,13 @@ func main() {
 	}
 
 	// create resource watcher (ingress)
-	watcher := cache.NewListWatchFromClient(clientset.ExtensionsV1beta1().RESTClient(), resource, v1.NamespaceAll, fields.Everything())
+	watcher := cache.NewListWatchFromClient(clientset.NetworkingV1().RESTClient(), resource, v1.NamespaceAll, fields.Everything())
 
-	_, controller := cache.NewInformer(watcher, &v1beta1.Ingress{}, 0, cache.ResourceEventHandlerFuncs{
+	_, controller := cache.NewInformer(watcher, &networkingv1.Ingress{}, 0, cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			key, err := cache.MetaNamespaceKeyFunc(obj)
 			if err == nil {
-				meta := obj.(*v1beta1.Ingress).ObjectMeta
+				meta := obj.(*networkingv1.Ingress).ObjectMeta
 				logrus.Infof("[Informer] Added Ingress %s", key)
 
 				settings, err := parseAnnotations(meta)
@@ -76,7 +76,7 @@ func main() {
 			key, err := cache.MetaNamespaceKeyFunc(new)
 
 			if err == nil {
-				meta := new.(*v1beta1.Ingress).ObjectMeta
+				meta := new.(*networkingv1.Ingress).ObjectMeta
 				logrus.Infof("[Informer] Update Ingress %s", key)
 
 				settings, err := parseAnnotations(meta)
@@ -88,7 +88,7 @@ func main() {
 		DeleteFunc: func(obj interface{}) {
 			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 			if err == nil {
-				meta := obj.(*v1beta1.Ingress).ObjectMeta
+				meta := obj.(*networkingv1.Ingress).ObjectMeta
 				logrus.Infof("[Informer] Delete Ingress: %s", key)
 
 				settings, err := parseAnnotations(meta)


### PR DESCRIPTION
## Why

extensions/v1beta1 is removed in Kubernetes 1.22

## What

replace with networking/v1