### PR TITLE
Allow "ingress-nginx" class

### DIFF
--- a/service/observer.go
+++ b/service/observer.go
@@ -93,8 +93,8 @@ func parseAnnotations(meta metav1.ObjectMeta) (*models.ServiceSettings, error) {
 	if _, ok := meta.Annotations["kubernetes.io/ingress.class"]; !ok {
 		return nil, errors.New("ingress.class not found. skip.")
 	} else if meta.Annotations["kubernetes.io/ingress.class"] != "nginx" && meta.Annotations["kubernetes.io/ingress.class"] != "ingress-nginx" {
-		// or ingress.class is "nginx" ?
-		return nil, errors.New("ingress.class is not nginx. skip.")
+		// or ingress.class is "nginx" or "ingress-nginx" ?
+		return nil, errors.New("ingress.class is not nginx or ingress-nginx. skip.")
 	}
 
 	if _, ok := meta.Annotations["nginx.ingress.kubernetes.io/auth-url"]; !ok {

--- a/service/observer.go
+++ b/service/observer.go
@@ -92,7 +92,7 @@ func parseAnnotations(meta metav1.ObjectMeta) (*models.ServiceSettings, error) {
 	// Check Annotations ---
 	if _, ok := meta.Annotations["kubernetes.io/ingress.class"]; !ok {
 		return nil, errors.New("ingress.class not found. skip.")
-	} else if meta.Annotations["kubernetes.io/ingress.class"] != "nginx" {
+	} else if meta.Annotations["kubernetes.io/ingress.class"] != "nginx" && meta.Annotations["kubernetes.io/ingress.class"] != "ingress-nginx" {
 		// or ingress.class is "nginx" ?
 		return nil, errors.New("ingress.class is not nginx. skip.")
 	}


### PR DESCRIPTION
## Why

We use `ingress-nginx` class instead of `nginx`, but the current logic skips operations.

## What

Run in also `ingress-nginx` class.