### PR TITLE
bump up oauth2-proxy v7.2.1

### DIFF
--- a/service/controller.go
+++ b/service/controller.go
@@ -221,7 +221,7 @@ func (c *Controller) applySecret(ctx context.Context, settings *models.ServiceSe
 			settings.GitHub.Organization+
 			strings.Join(settings.GitHub.Teams, "")+
 			settings.AppName+c.Env.CookieSalt,
-	)))
+	)))[0:32]
 	secret := &apiv1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("oauth2-proxy-github-%s-%s", settings.GitHub.Organization, settings.AppName),

--- a/service/controller.go
+++ b/service/controller.go
@@ -313,7 +313,7 @@ func (c *Controller) applyDeployment(ctx context.Context, settings *models.Servi
 					Containers: []apiv1.Container{
 						apiv1.Container{
 							Name:  "oauth2-proxy",
-							Image: "quay.io/pusher/oauth2_proxy:v3.2.0",
+							Image: "quay.io/oauth2-proxy/oauth2-proxy:v7.4.0",
 							Args: []string{
 								"--http-address=0.0.0.0:4180",
 								fmt.Sprintf("--cookie-domain=%s", c.Env.CookieDomain),

--- a/service/controller.go
+++ b/service/controller.go
@@ -313,7 +313,7 @@ func (c *Controller) applyDeployment(ctx context.Context, settings *models.Servi
 					Containers: []apiv1.Container{
 						apiv1.Container{
 							Name:  "oauth2-proxy",
-							Image: "quay.io/oauth2-proxy/oauth2-proxy:v7.4.0",
+							Image: "quay.io/oauth2-proxy/oauth2-proxy:v7.2.1",
 							Args: []string{
 								"--http-address=0.0.0.0:4180",
 								fmt.Sprintf("--cookie-domain=%s", c.Env.CookieDomain),

--- a/showcase/create-oauth2-proxy/main.go
+++ b/showcase/create-oauth2-proxy/main.go
@@ -250,7 +250,7 @@ func (o *OAuth2Proxy) applySecret(ctx context.Context) {
 		},
 		Type: apiv1.SecretTypeOpaque,
 		StringData: map[string]string{
-			fmt.Sprintf("%s-%s-%s-cookie-secret", o.Env.Provider, o.Settings.GitHub.Organization, o.Settings.AppName): "PLEASERANDOM",
+			fmt.Sprintf("%s-%s-%s-cookie-secret", o.Env.Provider, o.Settings.GitHub.Organization, o.Settings.AppName): "_RANDOM_STR_16_OR_24_OR_32_BYTE_",
 			"client-secret": o.Env.ClientSecret,
 			"client-id":     o.Env.ClientID,
 		},
@@ -330,7 +330,7 @@ func (o *OAuth2Proxy) applyDeployment(ctx context.Context) {
 					Containers: []apiv1.Container{
 						apiv1.Container{
 							Name:  "oauth2-proxy",
-							Image: "quay.io/oauth2-proxy/oauth2-proxy:v7.4.0",
+							Image: "quay.io/oauth2-proxy/oauth2-proxy:v7.2.1",
 							Args: []string{
 								"--http-address=0.0.0.0:4180",
 								fmt.Sprintf("--cookie-domain=%s", o.Env.CookieDomain),

--- a/showcase/create-oauth2-proxy/main.go
+++ b/showcase/create-oauth2-proxy/main.go
@@ -330,7 +330,7 @@ func (o *OAuth2Proxy) applyDeployment(ctx context.Context) {
 					Containers: []apiv1.Container{
 						apiv1.Container{
 							Name:  "oauth2-proxy",
-							Image: "quay.io/pusher/oauth2_proxy:v3.2.0",
+							Image: "quay.io/oauth2-proxy/oauth2-proxy:v7.4.0",
 							Args: []string{
 								"--http-address=0.0.0.0:4180",
 								fmt.Sprintf("--cookie-domain=%s", o.Env.CookieDomain),


### PR DESCRIPTION
## Why & What

bump up oauth2-proxy v7.2.1 (from v3.2.0)

- Use v7.2.1 (not latest)
  - ref.  [github broken in 7.3.0 #1724](https://togithub.com/oauth2-proxy/oauth2-proxy/issues/1724)
- Adapt cookie secret size (32bytes)
  - ref. [Fix secretBytes adding unintended padding #556](https://togithub.com/oauth2-proxy/oauth2-proxy/pull/556)
- Adapt new image registry
  - quay.io/oauth2-proxy/oauth2-proxy
- Full CHANGELOG of oauth2-proxy
  - https://github.com/oauth2-proxy/oauth2-proxy/blob/master/CHANGELOG.md